### PR TITLE
fix: numpy.float deprecation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-seaborn==0.9.0
+seaborn==0.13.2
 pandas==1.5.3


### PR DESCRIPTION
seaborn 0.9.0 uses numpy.float, an alias for the built in float that has been deprecated since numpy 1.20. As pandas 1.5.3 requires numpy 1.20.3 as an obligatory dependency, the seaborn package needed to be updated to a more recent version in order to avoid compatiblity errors.